### PR TITLE
feat: add Slack analytics bot with DuckDB snapshot ETL

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,6 +15,7 @@ services:
       - ../ct22-volumes/media:/ct22-volumes/media
       - ../ct22-volumes/bucket:/bucket
       - ../ct22-volumes/logs/ct-web:/var/log/ct-web
+      - ../ct22-volumes/duckdb:/duckdb
     command: /srv/start
     restart: "no"
     #env_file:
@@ -104,6 +105,22 @@ services:
       - POSTGRES_PASSWORD=example
       - POSTGRES_DB=cameratrap
       - CELERY_BROKER_URL=redis://redis:6379/3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "3"
+  slack_bot:
+    build:
+      context: ./slack_bot
+      dockerfile: Dockerfile
+    container_name: cameratrap-slack-bot-container
+    image: cameratrap-slack-bot-image
+    env_file:
+      - ./slack_bot/.env
+    volumes:
+      - ../ct22-volumes/duckdb:/data:ro
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:

--- a/cron_scripts/duckdb_etl.py
+++ b/cron_scripts/duckdb_etl.py
@@ -1,0 +1,200 @@
+"""Weekly ETL: PostgreSQL -> DuckDB snapshot for the Slack analytics bot.
+
+Run via:
+    python ./manage.py shell < ./cron_scripts/duckdb_etl.py
+
+Uses DuckDB's built-in ``postgres`` extension (formerly ``postgres_scanner``)
+to stream projected tables from the live Postgres database into a single
+DuckDB file. The file is written to /duckdb/cameratrap.duckdb inside the
+container (mounted from ../ct22-volumes/duckdb on the host) so the slack_bot
+service can read it via a read-only bind mount.
+"""
+import json
+import os
+import time
+from datetime import datetime
+
+import duckdb
+
+
+DUCKDB_PATH = os.environ.get('DUCKDB_PATH', '/duckdb/cameratrap.duckdb')
+
+PG = {
+    'host': os.environ.get('POSTGRES_HOST', 'postgres'),
+    'port': os.environ.get('POSTGRES_PORT', '5432'),
+    'dbname': os.environ.get('POSTGRES_DB', 'cameratrap'),
+    'user': os.environ.get('POSTGRES_USER', 'postgres'),
+    'password': os.environ.get('POSTGRES_PASSWORD', ''),
+}
+
+# Tables copied whole (small reference tables).
+FULL_TABLES = [
+    'taicat_project',
+    'taicat_studyarea',
+    'taicat_deployment',
+    'taicat_species',
+    'taicat_projectspecies',
+    'taicat_projectstat',
+    'taicat_deploymentstat',
+    'taicat_deploymentjournal',
+    'taicat_calculation',
+    'taicat_contact',
+    'taicat_organization',
+    'taicat_geostat',
+    'taicat_studyareastat',
+    'taicat_homepagestat',
+]
+
+# taicat_image is huge: project to the columns the bot actually needs.
+# Everything dropped here (annotation, remarks2, source_data, memo, image_hash,
+# EXIF-like fields) would dominate DB size without helping analytics queries.
+IMAGE_COLUMNS = [
+    'id',
+    'project_id',
+    'deployment_id',
+    'studyarea_id',
+    'deployment_journal_id',
+    'species',
+    'life_stage',
+    'sex',
+    'antler',
+    'animal_id',
+    'datetime',
+    'folder_name',
+    'image_uuid',
+    'has_storage',
+    'is_duplicated',
+    'created',
+    'last_updated',
+]
+
+
+def strip_prefix(table: str) -> str:
+    return table[len('taicat_'):] if table.startswith('taicat_') else table
+
+
+def attach_postgres(con):
+    dsn = (
+        f"host={PG['host']} port={PG['port']} dbname={PG['dbname']} "
+        f"user={PG['user']} password={PG['password']}"
+    )
+    con.execute('INSTALL postgres;')
+    con.execute('LOAD postgres;')
+    con.execute(f"ATTACH '{dsn}' AS pg (TYPE POSTGRES, READ_ONLY);")
+
+
+def copy_table(con, pg_table: str, columns: str = '*') -> int:
+    local = strip_prefix(pg_table)
+    con.execute(f'DROP TABLE IF EXISTS {local};')
+    con.execute(
+        f'CREATE TABLE {local} AS SELECT {columns} FROM pg.public.{pg_table};'
+    )
+    return con.execute(f'SELECT COUNT(*) FROM {local};').fetchone()[0]
+
+
+def build_views(con):
+    con.execute('''
+        CREATE OR REPLACE VIEW v_project_summary AS
+        SELECT
+            p.id                                AS project_id,
+            p.name                              AS project_name,
+            p.short_title,
+            p.funding_agency,
+            p.start_date,
+            p.end_date,
+            p.mode,
+            p.is_public,
+            COUNT(DISTINCT d.id)                AS n_deployments,
+            COUNT(DISTINCT s.id)                AS n_studyareas,
+            COUNT(i.id)                         AS n_images,
+            COUNT(DISTINCT NULLIF(i.species,'')) AS n_species,
+            MIN(i.datetime)                     AS first_image_at,
+            MAX(i.datetime)                     AS last_image_at
+        FROM project p
+        LEFT JOIN deployment d ON d.project_id = p.id
+        LEFT JOIN studyarea  s ON s.project_id = p.id
+        LEFT JOIN image      i ON i.project_id = p.id
+        GROUP BY p.id, p.name, p.short_title, p.funding_agency,
+                 p.start_date, p.end_date, p.mode, p.is_public;
+    ''')
+    con.execute('''
+        CREATE OR REPLACE VIEW v_species_by_project AS
+        SELECT
+            i.project_id,
+            p.name     AS project_name,
+            i.species,
+            COUNT(*)   AS n_images,
+            MIN(i.datetime) AS first_seen,
+            MAX(i.datetime) AS last_seen
+        FROM image i
+        JOIN project p ON p.id = i.project_id
+        WHERE i.species IS NOT NULL AND i.species <> ''
+        GROUP BY i.project_id, p.name, i.species;
+    ''')
+    con.execute('''
+        CREATE OR REPLACE VIEW v_species_total AS
+        SELECT species, COUNT(*) AS n_images
+        FROM image
+        WHERE species IS NOT NULL AND species <> ''
+        GROUP BY species
+        ORDER BY n_images DESC;
+    ''')
+
+
+def record_metadata(con, counts: dict, started_at: float):
+    con.execute('''
+        CREATE TABLE IF NOT EXISTS etl_metadata (
+            run_at          TIMESTAMP,
+            source_host     TEXT,
+            source_db       TEXT,
+            duration_sec    DOUBLE,
+            row_counts_json TEXT
+        );
+    ''')
+    con.execute(
+        'INSERT INTO etl_metadata VALUES (?, ?, ?, ?, ?);',
+        [
+            datetime.utcnow(),
+            PG['host'],
+            PG['dbname'],
+            time.time() - started_at,
+            json.dumps(counts, default=str),
+        ],
+    )
+
+
+def run():
+    started = time.time()
+    print(f'[duckdb_etl] writing snapshot to {DUCKDB_PATH}')
+    os.makedirs(os.path.dirname(DUCKDB_PATH), exist_ok=True)
+
+    con = duckdb.connect(DUCKDB_PATH)
+    attach_postgres(con)
+
+    counts: dict = {}
+    for table in FULL_TABLES:
+        try:
+            n = copy_table(con, table)
+        except duckdb.Error as exc:
+            print(f'[duckdb_etl] skip {table}: {exc}')
+            continue
+        counts[strip_prefix(table)] = n
+        print(f'[duckdb_etl] {table:32s} {n:>10,} rows')
+
+    counts['image'] = copy_table(con, 'taicat_image', ', '.join(IMAGE_COLUMNS))
+    print(f"[duckdb_etl] taicat_image                    {counts['image']:>10,} rows")
+
+    con.execute('CREATE INDEX IF NOT EXISTS idx_image_project   ON image(project_id);')
+    con.execute('CREATE INDEX IF NOT EXISTS idx_image_deploy    ON image(deployment_id);')
+    con.execute('CREATE INDEX IF NOT EXISTS idx_image_species   ON image(species);')
+    con.execute('CREATE INDEX IF NOT EXISTS idx_image_datetime  ON image(datetime);')
+
+    build_views(con)
+    record_metadata(con, counts, started)
+    con.execute('DETACH pg;')
+    con.close()
+
+    print(f'[duckdb_etl] done in {time.time() - started:.1f}s')
+
+
+run()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,7 @@ django-csp==3.8
 psycopg2-binary==2.9.9
 pymongo==4.8.0
 redis==5.0.8
+duckdb==1.1.3
 
 # utils
 openpyxl==3.1.5

--- a/slack_bot/.dockerignore
+++ b/slack_bot/.dockerignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/
+*.pyc
+tests/

--- a/slack_bot/.env.sample
+++ b/slack_bot/.env.sample
@@ -1,0 +1,13 @@
+# Slack app credentials (Socket Mode)
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_APP_TOKEN=xapp-...
+
+# Path inside the container where cameratrap.duckdb is mounted.
+DUCKDB_PATH=/data/cameratrap.duckdb
+
+# Comma-separated Slack channel IDs (e.g. C0123456789,C0987654321).
+# If set, /ct-* commands only work in these channels. Leave blank for any-channel.
+ALLOWED_CHANNEL_IDS=
+
+# Phase 3 (NL fallback) — leave blank in phase 1.
+ANTHROPIC_API_KEY=

--- a/slack_bot/.gitignore
+++ b/slack_bot/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.pyc

--- a/slack_bot/Dockerfile
+++ b/slack_bot/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    TZ=Asia/Taipei
+
+RUN ln -sf /usr/share/zoneinfo/Asia/Taipei /etc/localtime \
+ && echo "Asia/Taipei" > /etc/timezone
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip \
+ && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "-u", "bot.py"]

--- a/slack_bot/bot.py
+++ b/slack_bot/bot.py
@@ -1,0 +1,57 @@
+"""Slack Bolt entrypoint — Socket Mode (no public URL required)."""
+import logging
+import os
+
+from dotenv import load_dotenv
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+from commands import HANDLERS
+
+load_dotenv()
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+log = logging.getLogger('slack_bot')
+
+app = App(token=os.environ['SLACK_BOT_TOKEN'])
+
+ALLOWED_CHANNELS = {
+    c.strip() for c in os.environ.get('ALLOWED_CHANNEL_IDS', '').split(',') if c.strip()
+}
+
+
+def _register(cmd_name: str):
+    handler = HANDLERS[cmd_name]
+
+    @app.command(cmd_name)
+    def _run(ack, respond, command):
+        ack()
+        channel_id = command.get('channel_id', '')
+        channel_name = command.get('channel_name', '?')
+        user = command.get('user_name', '?')
+        text = command.get('text', '')
+
+        if ALLOWED_CHANNELS and channel_id not in ALLOWED_CHANNELS:
+            log.info('blocked cmd=%s user=%s channel=%s (%s)',
+                     cmd_name, user, channel_id, channel_name)
+            respond({
+                'response_type': 'ephemeral',
+                'text': f':no_entry: 本指令僅能在指定頻道使用。',
+            })
+            return
+
+        log.info('cmd=%s user=%s channel=%s text=%r',
+                 cmd_name, user, channel_name, text)
+        try:
+            reply = handler(text)
+        except Exception as exc:
+            log.exception('handler failed for %s', cmd_name)
+            reply = f':warning: 發生錯誤：`{exc}`'
+        respond({'response_type': 'ephemeral', 'text': reply})
+
+
+for _cmd in HANDLERS:
+    _register(_cmd)
+
+
+if __name__ == '__main__':
+    SocketModeHandler(app, os.environ['SLACK_APP_TOKEN']).start()

--- a/slack_bot/commands.py
+++ b/slack_bot/commands.py
@@ -1,0 +1,127 @@
+"""Slash command handlers (phase 1 MVP)."""
+import json
+
+from db import query, snapshot_info
+
+
+def cmd_help(text: str) -> str:
+    return (
+        '*Camera Trap 分析機器人*\n'
+        '`/ct-help`  顯示本說明\n'
+        '`/ct-projects [keyword]`  列出計畫（可用關鍵字過濾）\n'
+        '`/ct-stats <project_id|name>`  某計畫的統計摘要\n'
+        '`/ct-snapshot`  顯示目前資料快照時間\n'
+    )
+
+
+def cmd_projects(text: str) -> str:
+    keyword = (text or '').strip()
+    if keyword:
+        rows = query(
+            'SELECT project_id, project_name, n_deployments, n_images, n_species '
+            'FROM v_project_summary '
+            'WHERE project_name ILIKE ? OR COALESCE(short_title, \'\') ILIKE ? '
+            'ORDER BY n_images DESC LIMIT 25;',
+            (f'%{keyword}%', f'%{keyword}%'),
+        )
+    else:
+        rows = query(
+            'SELECT project_id, project_name, n_deployments, n_images, n_species '
+            'FROM v_project_summary '
+            'ORDER BY n_images DESC LIMIT 25;'
+        )
+
+    if not rows:
+        return f'找不到符合「{keyword}」的計畫。'
+
+    header = f'*計畫列表{f"（關鍵字：{keyword}）" if keyword else ""}* — 共 {len(rows)} 筆'
+    lines = [header, '```', f'{"id":>5}  {"相機數":>6}  {"影像數":>10}  {"物種數":>6}  計畫名稱']
+    for pid, name, ndep, nimg, nsp in rows:
+        lines.append(
+            f'{pid:>5}  {(ndep or 0):>6}  {(nimg or 0):>10,}  {(nsp or 0):>6}  {name}'
+        )
+    lines.append('```')
+    return '\n'.join(lines)
+
+
+def cmd_stats(text: str) -> str:
+    target = (text or '').strip()
+    if not target:
+        return '用法：`/ct-stats <project_id|計畫名稱關鍵字>`'
+
+    if target.isdigit():
+        rows = query(
+            'SELECT project_id, project_name, short_title, funding_agency, '
+            '       start_date, end_date, mode, is_public, '
+            '       n_deployments, n_studyareas, n_images, n_species, '
+            '       first_image_at, last_image_at '
+            'FROM v_project_summary WHERE project_id = ? LIMIT 1;',
+            (int(target),),
+        )
+    else:
+        rows = query(
+            'SELECT project_id, project_name, short_title, funding_agency, '
+            '       start_date, end_date, mode, is_public, '
+            '       n_deployments, n_studyareas, n_images, n_species, '
+            '       first_image_at, last_image_at '
+            'FROM v_project_summary '
+            'WHERE project_name ILIKE ? OR COALESCE(short_title, \'\') ILIKE ? '
+            'ORDER BY n_images DESC LIMIT 1;',
+            (f'%{target}%', f'%{target}%'),
+        )
+
+    if not rows:
+        return f'找不到計畫「{target}」。'
+
+    (pid, name, short, funder, sd, ed, mode, is_public,
+     ndep, nsa, nimg, nsp, first_dt, last_dt) = rows[0]
+
+    top_species = query(
+        'SELECT species, COUNT(*) AS n '
+        'FROM image WHERE project_id = ? AND species IS NOT NULL AND species <> \'\' '
+        'GROUP BY species ORDER BY n DESC LIMIT 10;',
+        (pid,),
+    )
+
+    parts = [
+        f'*{name}* (id: `{pid}`)',
+        f'簡稱：{short or "—"}｜委辦單位：{funder or "—"}｜模式：{mode or "—"}｜公開：{"是" if is_public else "否"}',
+        f'計畫期間：{sd or "—"} ~ {ed or "—"}',
+        '',
+        f'相機位置：{ndep or 0}　樣區：{nsa or 0}　影像總數：{(nimg or 0):,}　物種數：{nsp or 0}',
+        f'最早影像：{first_dt or "—"}　最晚影像：{last_dt or "—"}',
+    ]
+    if top_species:
+        parts.append('')
+        parts.append('*Top 10 物種*')
+        parts.append('```')
+        for sp, n in top_species:
+            parts.append(f'{n:>10,}  {sp}')
+        parts.append('```')
+    return '\n'.join(parts)
+
+
+def cmd_snapshot(text: str) -> str:
+    info = snapshot_info()
+    if not info:
+        return '找不到資料快照。請先執行每週 ETL。'
+    counts = json.loads(info['row_counts_json'] or '{}')
+    top = sorted(counts.items(), key=lambda kv: kv[1] or 0, reverse=True)[:6]
+    lines = [
+        f'*快照時間*: {info["run_at"]} UTC',
+        f'ETL 耗時: {info["duration_sec"]:.1f}s',
+        '*主要資料表列數*:',
+        '```',
+    ]
+    for name, n in top:
+        lines.append(f'{n or 0:>12,}  {name}')
+    lines.append('```')
+    return '\n'.join(lines)
+
+
+HANDLERS = {
+    '/ct-help': cmd_help,
+    '/ct-projects': cmd_projects,
+    '/ct-stats': cmd_stats,
+    '/ct-snapshot': cmd_snapshot,
+}

--- a/slack_bot/db.py
+++ b/slack_bot/db.py
@@ -1,0 +1,44 @@
+"""Read-only DuckDB access helpers."""
+import os
+import threading
+from contextlib import contextmanager
+
+import duckdb
+
+DUCKDB_PATH = os.environ.get('DUCKDB_PATH', '/data/cameratrap.duckdb')
+
+_lock = threading.Lock()
+
+
+@contextmanager
+def connect():
+    """Open a read-only connection to the snapshot file.
+
+    DuckDB supports multiple read-only connections, but we serialize here
+    anyway so slow queries can't overlap and starve the bot's event loop.
+    """
+    with _lock:
+        con = duckdb.connect(DUCKDB_PATH, read_only=True)
+        try:
+            yield con
+        finally:
+            con.close()
+
+
+def query(sql: str, params: tuple = ()):
+    with connect() as con:
+        return con.execute(sql, params).fetchall()
+
+
+def snapshot_info() -> dict | None:
+    try:
+        row = query(
+            'SELECT run_at, duration_sec, row_counts_json '
+            'FROM etl_metadata ORDER BY run_at DESC LIMIT 1;'
+        )
+    except duckdb.Error:
+        return None
+    if not row:
+        return None
+    run_at, duration, counts = row[0]
+    return {'run_at': run_at, 'duration_sec': duration, 'row_counts_json': counts}

--- a/slack_bot/requirements.txt
+++ b/slack_bot/requirements.txt
@@ -1,0 +1,3 @@
+slack-bolt==1.21.2
+duckdb==1.1.3
+python-dotenv==1.0.1


### PR DESCRIPTION
Bot runs in its own container via Socket Mode and answers /ct-help, /ct-projects, /ct-stats, /ct-snapshot against a weekly-refreshable DuckDB snapshot of the Postgres database. ETL is a standalone script run manually via manage.py shell; no cron wiring.