### PR TITLE
feat: add /ct-ask natural-language query via Claude Sonnet

### DIFF
--- a/slack_bot/commands.py
+++ b/slack_bot/commands.py
@@ -1,7 +1,8 @@
-"""Slash command handlers (phase 1 MVP)."""
+"""Slash command handlers."""
 import json
 
 from db import query, snapshot_info
+from nl_query import ask
 
 
 def cmd_help(text: str) -> str:
@@ -11,6 +12,7 @@ def cmd_help(text: str) -> str:
         '`/ct-projects [keyword]`  列出計畫（可用關鍵字過濾）\n'
         '`/ct-stats <project_id|name>`  某計畫的統計摘要\n'
         '`/ct-snapshot`  顯示目前資料快照時間\n'
+        '`/ct-ask <問題>`  用自然語言提問（LLM 生成 SQL）\n'
     )
 
 
@@ -124,4 +126,5 @@ HANDLERS = {
     '/ct-projects': cmd_projects,
     '/ct-stats': cmd_stats,
     '/ct-snapshot': cmd_snapshot,
+    '/ct-ask': ask,
 }

--- a/slack_bot/nl_query.py
+++ b/slack_bot/nl_query.py
@@ -1,0 +1,140 @@
+"""Natural-language querying: question -> SQL -> DuckDB -> summary."""
+import logging
+import os
+from pathlib import Path
+
+import anthropic
+import duckdb
+
+from db import DUCKDB_PATH
+from safety import UnsafeSQLError, sanitize
+
+log = logging.getLogger('nl_query')
+
+MODEL = os.environ.get('ANTHROPIC_MODEL', 'claude-sonnet-4-6')
+MAX_ROWS = 500
+QUERY_TIMEOUT_MS = 15_000
+
+_schema_path = Path(__file__).parent / 'schema.md'
+SCHEMA_DOC = _schema_path.read_text(encoding='utf-8')
+
+SQLGEN_SYSTEM = (
+    'You convert Chinese/English wildlife camera-trap analytics questions into '
+    'a single read-only DuckDB SQL query. Output ONLY the SQL, no prose, no '
+    'code fences, no explanation. Follow every rule in the schema document.'
+)
+
+SUMMARY_SYSTEM = (
+    '你是台灣野生動物相機陷阱資料分析助手。根據 SQL 查詢結果以繁體中文簡潔回答使用者的問題。'
+    '若結果為空，直接說「查無資料」。若有數字，保留合理精度。不要複述 SQL。'
+    '回答長度控制在三段以內。'
+)
+
+_client: anthropic.Anthropic | None = None
+
+
+def _anthropic() -> anthropic.Anthropic:
+    global _client
+    if _client is None:
+        _client = anthropic.Anthropic(api_key=os.environ['ANTHROPIC_API_KEY'])
+    return _client
+
+
+def _generate_sql(question: str) -> str:
+    resp = _anthropic().messages.create(
+        model=MODEL,
+        max_tokens=1024,
+        system=[
+            {'type': 'text', 'text': SQLGEN_SYSTEM},
+            {
+                'type': 'text',
+                'text': SCHEMA_DOC,
+                'cache_control': {'type': 'ephemeral'},
+            },
+        ],
+        messages=[{'role': 'user', 'content': question}],
+    )
+    return ''.join(b.text for b in resp.content if b.type == 'text')
+
+
+def _execute(sql: str) -> tuple[list[str], list[tuple]]:
+    con = duckdb.connect(DUCKDB_PATH, read_only=True)
+    try:
+        con.execute(f"SET statement_timeout = '{QUERY_TIMEOUT_MS}ms';")
+        cursor = con.execute(sql)
+        rows = cursor.fetchmany(MAX_ROWS)
+        columns = [d[0] for d in cursor.description] if cursor.description else []
+        return columns, rows
+    finally:
+        con.close()
+
+
+def _summarize(question: str, sql: str, columns: list[str], rows: list[tuple]) -> str:
+    sample = rows[:50]
+    preview = {
+        'columns': columns,
+        'rows': [[str(v) for v in r] for r in sample],
+        'truncated': len(rows) > len(sample),
+        'total_rows_returned': len(rows),
+    }
+    prompt = (
+        f'使用者問題：{question}\n\n'
+        f'執行的 SQL：\n```sql\n{sql}\n```\n\n'
+        f'查詢結果（JSON）：\n```json\n{preview}\n```\n\n'
+        '請用繁體中文回答使用者的問題。'
+    )
+    resp = _anthropic().messages.create(
+        model=MODEL,
+        max_tokens=1024,
+        system=SUMMARY_SYSTEM,
+        messages=[{'role': 'user', 'content': prompt}],
+    )
+    return ''.join(b.text for b in resp.content if b.type == 'text').strip()
+
+
+def _format_table(columns: list[str], rows: list[tuple], cap: int = 10) -> str:
+    if not rows:
+        return ''
+    shown = rows[:cap]
+    widths = [len(c) for c in columns]
+    for row in shown:
+        for i, v in enumerate(row):
+            widths[i] = max(widths[i], len(str(v)))
+    header = '  '.join(c.ljust(widths[i]) for i, c in enumerate(columns))
+    body = '\n'.join(
+        '  '.join(str(v).ljust(widths[i]) for i, v in enumerate(row))
+        for row in shown
+    )
+    more = f'\n…（共 {len(rows)} 列）' if len(rows) > cap else ''
+    return f'```\n{header}\n{body}{more}\n```'
+
+
+def ask(question: str) -> str:
+    question = (question or '').strip()
+    if not question:
+        return '用法：`/ct-ask <問題>`，例如：`/ct-ask 2024 年哪個計畫拍到最多石虎？`'
+
+    try:
+        raw_sql = _generate_sql(question)
+        log.info('raw_sql=%r', raw_sql)
+        sql = sanitize(raw_sql)
+    except UnsafeSQLError as exc:
+        return f':warning: SQL 檢查失敗：{exc}'
+    except anthropic.APIError as exc:
+        log.exception('anthropic failed')
+        return f':warning: LLM 呼叫失敗：`{exc}`'
+
+    try:
+        columns, rows = _execute(sql)
+    except duckdb.Error as exc:
+        return f':warning: 查詢失敗：`{exc}`\n產生的 SQL：\n```sql\n{sql}\n```'
+
+    try:
+        answer = _summarize(question, sql, columns, rows)
+    except anthropic.APIError as exc:
+        log.exception('summary failed')
+        answer = f'(無法取得摘要：{exc})'
+
+    parts = [answer, _format_table(columns, rows)]
+    parts.append(f'_SQL:_ `{sql}`')
+    return '\n\n'.join(p for p in parts if p)

--- a/slack_bot/requirements.txt
+++ b/slack_bot/requirements.txt
@@ -1,3 +1,4 @@
 slack-bolt==1.21.2
 duckdb==1.1.3
 python-dotenv==1.0.1
+anthropic==0.40.0

--- a/slack_bot/safety.py
+++ b/slack_bot/safety.py
@@ -1,0 +1,34 @@
+"""SQL safety guards for LLM-generated queries."""
+import re
+
+FORBIDDEN = re.compile(
+    r'\b(INSERT|UPDATE|DELETE|DROP|ATTACH|DETACH|COPY|PRAGMA|CREATE|ALTER|'
+    r'REPLACE|LOAD|INSTALL|EXPORT|IMPORT|VACUUM|CHECKPOINT|SET|CALL|EXECUTE|'
+    r'USE|TRUNCATE|GRANT|REVOKE)\b',
+    re.IGNORECASE,
+)
+
+
+class UnsafeSQLError(Exception):
+    pass
+
+
+def sanitize(sql: str) -> str:
+    """Return a cleaned SQL string or raise UnsafeSQLError."""
+    sql = sql.strip()
+    # Strip markdown code fences if the LLM added them.
+    if sql.startswith('```'):
+        sql = re.sub(r'^```(?:sql)?\s*', '', sql)
+        sql = re.sub(r'\s*```$', '', sql)
+    sql = sql.strip().rstrip(';').strip()
+
+    if not sql:
+        raise UnsafeSQLError('空白查詢')
+    if not re.match(r'^(SELECT|WITH)\b', sql, re.IGNORECASE):
+        raise UnsafeSQLError('只允許 SELECT 或 WITH 開頭的查詢')
+    if ';' in sql:
+        raise UnsafeSQLError('只允許單一查詢')
+    if FORBIDDEN.search(sql):
+        raise UnsafeSQLError('查詢包含禁止的關鍵字')
+
+    return sql

--- a/slack_bot/schema.md
+++ b/slack_bot/schema.md
@@ -1,0 +1,183 @@
+# Camera Trap DuckDB Schema
+
+The database is a weekly snapshot of a Django PostgreSQL wildlife camera-trap
+system. All species names are in Traditional Chinese (zh-TW). Timestamps are
+stored in UTC; the project operates in Taiwan (UTC+8).
+
+## Tables
+
+### project
+Research projects. One project owns many studyareas and many deployments.
+
+| column | type | notes |
+|---|---|---|
+| id | INTEGER PK | |
+| name | TEXT | 計畫名稱 (full name) |
+| short_title | TEXT | 計畫簡稱 |
+| description | TEXT | 計畫摘要 |
+| keyword | TEXT | search keywords |
+| start_date | DATE | |
+| end_date | DATE | |
+| executive_unit | TEXT | 執行單位 |
+| principal_investigator | TEXT | 計畫主持人 |
+| funding_agency | TEXT | 委辦單位 |
+| region | TEXT | 計畫地區 |
+| mode | TEXT | 'official' or 'test' — filter `mode = 'official'` for real projects |
+| is_public | BOOLEAN | |
+| publish_date | DATE | |
+
+### studyarea
+Named survey regions within a project. Hierarchical (parent_id self-reference).
+
+| column | type | notes |
+|---|---|---|
+| id | INTEGER PK | |
+| name | TEXT | |
+| parent_id | INTEGER | self FK; NULL for top-level |
+| project_id | INTEGER FK → project.id | |
+
+### deployment
+Individual camera trap locations. One studyarea has many deployments.
+
+| column | type | notes |
+|---|---|---|
+| id | INTEGER PK | |
+| name | TEXT | 相機位置名稱 |
+| project_id | INTEGER FK → project.id | |
+| study_area_id | INTEGER FK → studyarea.id | NOTE: column is `study_area_id` not `studyarea_id` |
+| longitude | DECIMAL | |
+| latitude | DECIMAL | |
+| altitude | SMALLINT | |
+| geodetic_datum | TEXT | 'TWD97' or 'WGS84' |
+| county | TEXT | 縣市 code — join taicat_parametercode if translating |
+| protectedarea | TEXT | 國家公園/保護留區 code |
+| landcover | TEXT | 土地覆蓋 |
+| vegetation | TEXT | 植被類型 |
+| camera_status | TEXT | '1'=正常, '2'-'6'=各種故障/失竊 |
+| deprecated | BOOLEAN | skip when TRUE |
+
+### image
+Individual wildlife photos. Biggest table (tens of millions of rows).
+Only a projection of relevant columns is in the snapshot (no annotation JSON,
+no raw EXIF, no thumbnails).
+
+| column | type | notes |
+|---|---|---|
+| id | BIGINT PK | |
+| project_id | INTEGER | |
+| deployment_id | INTEGER | |
+| studyarea_id | INTEGER | |
+| deployment_journal_id | INTEGER | |
+| species | TEXT | 中文俗名 e.g. '水鹿', '山羌', '台灣黑熊'; empty string or NULL = unidentified |
+| life_stage | TEXT | 生命階段 e.g. '成體', '幼體' |
+| sex | TEXT | '雄', '雌', '' |
+| antler | TEXT | rack/antler status |
+| animal_id | TEXT | individual animal ID when known |
+| datetime | TIMESTAMP | when photo was captured (UTC) |
+| folder_name | TEXT | uploader batch name |
+| image_uuid | TEXT | |
+| has_storage | TEXT | 'Y' if S3 file present, 'N' otherwise |
+| is_duplicated | TEXT | '', 'Y', ... |
+
+Common species values worth knowing: 水鹿, 山羌, 獼猴, 野山羊, 野豬, 鼬獾,
+白鼻心, 食蟹獴, 松鼠, 飛鼠, 黃喉貂, 黃鼠狼, 小黃鼠狼, 麝香貓, 黑熊 (aka 台灣黑熊),
+石虎, 穿山甲, 梅花鹿, 野兔, 蝙蝠.
+
+Non-wildlife labels to usually exclude from species queries unless the user
+asks about them explicitly: 人, 人（有槍）, 人＋狗, 狗＋人, 獵人, 砍草工人,
+研究人員, 研究人員自己, 除草工人.
+
+### species
+Master species list with global counts.
+
+| column | type | notes |
+|---|---|---|
+| id | INTEGER PK | |
+| name | TEXT | |
+| count | INTEGER | cached total image count |
+| is_default | BOOLEAN | is on the standard 20-species list |
+| last_updated | TIMESTAMP | |
+
+### deploymentjournal
+Camera working periods. Each row = one continuous working interval for a
+deployment. Use to compute camera-hours / effective survey days.
+
+| column | type | notes |
+|---|---|---|
+| id | INTEGER PK | |
+| project_id | INTEGER | |
+| deployment_id | INTEGER | |
+| studyarea_id | INTEGER | |
+| working_start | TIMESTAMP | |
+| working_end | TIMESTAMP | |
+| is_effective | BOOLEAN | TRUE = camera actually recording |
+| is_gap | BOOLEAN | TRUE = confirmed data gap |
+| gap_caused | TEXT | |
+
+### calculation
+Pre-computed wildlife density indices (OI1/OI2/OI3) per deployment × species ×
+year × month, for several `image_interval` / `event_interval` combinations.
+
+| column | type | notes |
+|---|---|---|
+| id | INTEGER PK | |
+| project_id | INTEGER | |
+| studyarea_id | INTEGER | |
+| deployment_id | INTEGER | |
+| datetime_from | TIMESTAMP | |
+| datetime_to | TIMESTAMP | |
+| species | TEXT | |
+| image_interval | SMALLINT | minutes — usually 30 or 60 |
+| event_interval | SMALLINT | minutes — usually 2, 5, 10, 30, 60 |
+| data | JSON | see structure below |
+
+`calculation.data` JSON typically contains keys like `oi1`, `oi2`, `oi3`,
+`num_images`, `num_events`, `working_hours`. To extract a number:
+`CAST(json_extract(data, '$.oi3') AS DOUBLE)`. When in doubt, pick
+`image_interval=30 AND event_interval=5` as defaults.
+
+### deploymentstat, projectstat, projectspecies, homepagestat, geostat, studyareastat
+Pre-aggregated convenience tables. Generally useful for fast summaries.
+
+- `projectstat(project_id, num_sa, num_deployment, num_data, earliest_date, latest_date, last_updated)`
+- `projectspecies(project_id, name, count, last_updated)` — species × project counts
+- `deploymentstat(deployment_id, count_working_hour, ...)` — per-deployment totals
+- `geostat(county, num_project, num_deployment, num_image, num_working_hour, identified, species, studyarea)` — per-county rollup
+- `homepagestat(year, count, last_updated)` — yearly cumulative image counts
+
+### contact, organization
+User accounts & organizations. Usually not needed for analytics.
+
+## Convenience views
+
+Already defined in the snapshot:
+
+- `v_project_summary(project_id, project_name, short_title, funding_agency,
+  start_date, end_date, mode, is_public, n_deployments, n_studyareas,
+  n_images, n_species, first_image_at, last_image_at)` — one row per project.
+- `v_species_by_project(project_id, project_name, species, n_images,
+  first_seen, last_seen)` — species counts per project (excludes
+  NULL/empty species).
+- `v_species_total(species, n_images)` — global species counts, sorted.
+
+## Query rules
+
+1. Return exactly **one** `SELECT` (or `WITH ... SELECT`) statement. No DDL,
+   DML, PRAGMA, ATTACH, COPY, LOAD, INSTALL, CREATE, DROP, ALTER, UPDATE,
+   INSERT, DELETE, REPLACE, EXPORT, IMPORT, VACUUM, CHECKPOINT. The query
+   runs in a read-only connection.
+2. Always add `LIMIT` (≤ 500). If the user asks for "all", cap at 500 anyway.
+3. For species matching, use `ILIKE` with wildcards so users can search
+   "黑熊" and match "台灣黑熊": `species ILIKE '%黑熊%'`.
+4. When filtering projects by name, search both `name` and `short_title`
+   with `ILIKE`.
+5. When grouping by time, extract parts with `date_part('year', datetime)`
+   and `date_part('month', datetime)`.
+6. When comparing to "now" or "recent", use `CURRENT_DATE` / `NOW()`.
+7. Prefer the convenience views and pre-aggregated tables when possible —
+   they are much faster than scanning `image`.
+8. Exclude rows with `species IS NULL OR species = ''` when answering
+   species-level questions, unless the user specifically asked about
+   unidentified photos.
+9. Exclude `project.mode = 'test'` when answering questions about "all
+   projects" or producing global numbers, unless the user asks for tests.


### PR DESCRIPTION
Pipeline: question -> LLM generates DuckDB SELECT (with cached schema prompt) -> regex/read-only safety guards -> execute with 15s timeout and 500-row cap -> LLM summarizes results in zh-TW. Schema doc lives at slack_bot/schema.md and is the single place to tune prompting.