### PR TITLE
chore: move slack_bot service out of production compose

### DIFF
--- a/compose.override.yml
+++ b/compose.override.yml
@@ -11,3 +11,19 @@ services:
       - postgres
     ports:
       - 8080:8080
+  slack_bot:
+    build:
+      context: ./slack_bot
+      dockerfile: Dockerfile
+    container_name: cameratrap-slack-bot-container
+    image: cameratrap-slack-bot-image
+    env_file:
+      - ./slack_bot/.env
+    volumes:
+      - ../ct22-volumes/duckdb:/data:ro
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "3"

--- a/compose.yml
+++ b/compose.yml
@@ -110,19 +110,3 @@ services:
       options:
         max-size: "1m"
         max-file: "3"
-  slack_bot:
-    build:
-      context: ./slack_bot
-      dockerfile: Dockerfile
-    container_name: cameratrap-slack-bot-container
-    image: cameratrap-slack-bot-image
-    env_file:
-      - ./slack_bot/.env
-    volumes:
-      - ../ct22-volumes/duckdb:/data:ro
-    restart: unless-stopped
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "1m"
-        max-file: "3"


### PR DESCRIPTION
Relocated slack_bot from compose.yml (base, included in prod) to compose.override.yml (local dev only). Production deployments using -f compose.yml -f compose.prod.yml will no longer start the slack bot.