### PR TITLE
Add Camtrap DP export script and enhance image edit modal

### DIFF
--- a/scripts/swap-deployment.py
+++ b/scripts/swap-deployment.py
@@ -5,6 +5,11 @@ Selects images by one of three mutually-exclusive ways and re-points them to
 a target deployment, keeping the denormalized studyarea_id / project_id in
 sync with that deployment. Dry-run by default; pass --commit to write.
 
+The DeploymentJournal rows the selected images belong to (via
+Image.deployment_journal_id) are moved onto the target deployment as well:
+their deployment_id / studyarea_id are updated to match. This keeps each
+journal consistent with its images. No extra flag is needed.
+
 Selection modes (choose exactly one):
   --from-deployment <id>          all images currently on this deployment
   --project <id> --folder <name>  images of this project in this folder
@@ -15,16 +20,13 @@ Target:
   --to-deployment <id>            the deployment to move the images onto
 
 Options:
-  --update-journal   also re-point Image.deployment_journal_id to the target
-                     deployment's journal matching the image's folder_name
-                     (only when an unambiguous match exists)
   --commit           perform the update inside a transaction
                      (without it, nothing is written)
 
 Examples:
   python scripts/swap-deployment.py --from-deployment 13909 --to-deployment 14001
   python scripts/swap-deployment.py --project 329 --folder ABC0001 --to-deployment 14001 --commit
-  python scripts/swap-deployment.py --image-ids 1,2,3 --to-deployment 14001 --update-journal --commit
+  python scripts/swap-deployment.py --image-ids 1,2,3 --to-deployment 14001 --commit
 
 Cross-project moves are refused: per-project species/stat/folder counts would
 need recalculation. Use the image edit UI (api/edit_image) for those.
@@ -53,7 +55,6 @@ def parse_args():
     p.add_argument('--folder', action='append', default=[], help='folder_name (repeatable, use with --project)')
     p.add_argument('--image-ids', help='explicit comma-separated image ids')
     p.add_argument('--to-deployment', type=int, required=True, help='target deployment id')
-    p.add_argument('--update-journal', action='store_true', help='also re-point deployment_journal_id when an unambiguous match exists')
     p.add_argument('--commit', action='store_true', help='write changes (default: dry run)')
     return p.parse_args()
 
@@ -120,26 +121,34 @@ def main():
         print(f'  ({s["deployment_id"]}, {s["studyarea_id"]})  x{n}  ->  '
               f'({target.id}, {target.study_area_id})')
 
+    now = timezone.now()
     update_fields = {
         'deployment_id': target.id,
         'studyarea_id': target.study_area_id,
         'project_id': target.project_id,
-        'last_updated': timezone.now(),
+        'last_updated': now,
     }
 
-    # Optional journal re-pointing, per folder_name, only when unambiguous.
-    journal_map = {}
-    if args.update_journal:
-        folders = [f for f in qs.order_by('folder_name').values_list('folder_name', flat=True).distinct() if f]
-        for f in folders:
-            matches = list(DeploymentJournal.objects.filter(
-                deployment_id=target.id, folder_name=f).values_list('id', flat=True))
-            if len(matches) == 1:
-                journal_map[f] = matches[0]
-            else:
-                print(f'  WARN: {len(matches)} journals match deployment {target.id} '
-                      f'folder "{f}"; leaving deployment_journal_id unchanged for it.')
-        print(f'Journal re-points : {len(journal_map)} folder(s) will update deployment_journal_id')
+    # Move the journals these images belong to onto the target deployment too,
+    # so each DeploymentJournal stays consistent with its images.
+    journal_ids = set(
+        qs.exclude(deployment_journal_id__isnull=True)
+          .order_by('deployment_journal_id')
+          .values_list('deployment_journal_id', flat=True)
+          .distinct()
+    )
+    journal_qs = DeploymentJournal.objects.filter(id__in=journal_ids)
+    print(f'Journals to move  : {len(journal_ids)} '
+          f'(set deployment_id -> {target.id}, studyarea_id -> {target.study_area_id})')
+
+    # Warn if a journal also serves images outside this selection: moving it
+    # would leave those images mismatched against their journal's deployment.
+    for jid in sorted(journal_ids):
+        total_j = Image.objects.filter(deployment_journal_id=jid).count()
+        in_sel = qs.filter(deployment_journal_id=jid).count()
+        if total_j > in_sel:
+            print(f'  WARN: journal {jid} has {total_j - in_sel} image(s) NOT in this '
+                  f'selection; they would no longer match their journal deployment.')
 
     if not args.commit:
         print('\nDRY RUN — no changes written. Re-run with --commit to apply.')
@@ -147,11 +156,12 @@ def main():
 
     with transaction.atomic():
         n = qs.update(**update_fields)
-        j_total = 0
-        for folder, jid in journal_map.items():
-            j_total += qs.filter(folder_name=folder).update(deployment_journal_id=jid)
-    print(f'\nDONE: updated {n} image(s)'
-          + (f', re-pointed {j_total} image(s) to matching journals.' if args.update_journal else '.'))
+        j = journal_qs.update(
+            deployment_id=target.id,
+            studyarea_id=target.study_area_id,
+            last_updated=now,
+        )
+    print(f'\nDONE: updated {n} image(s), moved {j} journal(s) to deployment {target.id}.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…nting images

Drop --update-journal. By default the script now updates the DeploymentJournal rows the selected images belong to (via deployment_journal_id), setting their deployment_id/studyarea_id to the target so each journal stays consistent with its images. Warns when a journal also serves images outside the selection.