### PR TITLE
fix: truly lock studyarea/deployment in edit modal (readonly wasn't e…

### DIFF
--- a/static/js/project_detail.js
+++ b/static/js/project_detail.js
@@ -1231,8 +1231,10 @@ $(document).ready(function () {
       $('.edit-content input').prop("disabled", false)
       $('.edit-footer').removeClass('d-none')
       // 僅開放物種及標註欄位（年齡/性別/角況/個體ID/備註）編輯，
-      // 鎖定日期、時間、計畫（樣區與相機位置已於 HTML 設為唯讀）
-      $('#edit-date, #edit-time, #edit-project').attr('disabled', 'disabled');
+      // 鎖定日期、時間、計畫、樣區、相機位置。
+      // 注意：樣區與相機位置不能只用 HTML readonly，因為 readonly 欄位仍可被
+      // 點擊聚焦而觸發 autocomplete 下拉選單改值；必須一併 disabled 才會真正鎖定。
+      $('#edit-date, #edit-time, #edit-project, #edit-studyarea, #edit-deployment').attr('disabled', 'disabled');
       $('.edit-date-cal').addClass('d-none');
       console.log('edit mode')
     }
@@ -1457,8 +1459,10 @@ function changeEditContent(row) {
     $('.edit-content input').prop("disabled", false)
     $('.edit-footer').removeClass('d-none')
     // 僅開放物種及標註欄位（年齡/性別/角況/個體ID/備註）編輯，
-    // 鎖定日期、時間、計畫（樣區與相機位置已於 HTML 設為唯讀）
-    $('#edit-date, #edit-time, #edit-project').attr('disabled', 'disabled');
+    // 鎖定日期、時間、計畫、樣區、相機位置。
+    // 注意：樣區與相機位置不能只用 HTML readonly，因為 readonly 欄位仍可被
+    // 點擊聚焦而觸發 autocomplete 下拉選單改值；必須一併 disabled 才會真正鎖定。
+    $('#edit-date, #edit-time, #edit-project, #edit-studyarea, #edit-deployment').attr('disabled', 'disabled');
     $('.edit-date-cal').addClass('d-none');
   }
 


### PR DESCRIPTION
…nough)

樣區 and 相機位置 were locked with HTML readonly, which only blocks typing. Both fields have a jQuery UI autocomplete that opens its dropdown on focus, so the grayed-out fields could still be changed by clicking and picking an item (the select/change callbacks write .val() programmatically).

Add them to the disabled set alongside date/time/project in both edit-mode branches. Disabled inputs don't fire focus/click, so the dropdown can't open. Submission is unaffected: values POST via the still-enabled hidden _id inputs.