### PR TITLE
feat: search uploader name in upload-history

### DIFF
--- a/base/views.py
+++ b/base/views.py
@@ -420,7 +420,8 @@ def upload_history(request):
                 query = query.filter(Q(deployment_journal__project__name__icontains=q) |
                                      Q(deployment_journal__folder_name__icontains=q) |
                                      Q(deployment_journal__studyarea__name__icontains=q) |
-                                     Q(deployment_journal__deployment__name__icontains=q))
+                                     Q(deployment_journal__deployment__name__icontains=q) |
+                                     Q(deployment_journal__uploader__name__icontains=q))
 
             paginator = Paginator(query.all(), 20)
             page_obj = paginator.get_page(page_number)


### PR DESCRIPTION
## Summary
Add the uploader name to the `/upload-history` search filter so the query box also matches against the deployment journal uploader, in addition to project name, folder name, study area, and deployment name.

## Changes
- `base/views.py`: add `Q(deployment_journal__uploader__name__icontains=q)` to the upload-history search filter (applies to both contractor and non-contractor query paths). The uploader name was already selected and displayed in results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)