### PR TITLE
fix: use canonical OSM tile endpoint to avoid 403 block

### DIFF
--- a/static/js/home.js
+++ b/static/js/home.js
@@ -287,9 +287,10 @@ $(function () {
 
 
   let map = L.map("map", {tap: false}).setView([23.5, 121.2], 7);
-  L.tileLayer("https://{s}.tile.osm.org/{z}/{x}/{y}.png", {
+  L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    maxZoom: 19,
     attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors',
-    referrerPolicy: "no-referrer-when-downgrade",
+    referrerPolicy: "strict-origin-when-cross-origin",
   }).addTo(map);
 
   function onEachFeature(feature, layer) {

--- a/static/js/project_info.js
+++ b/static/js/project_info.js
@@ -2,9 +2,10 @@
 var $csrf_token = $('[name="csrfmiddlewaretoken"]').attr('value');
 
 let map = L.map("map", {tap: false});
-L.tileLayer("https://{s}.tile.osm.org/{z}/{x}/{y}.png", {
+L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  maxZoom: 19,
   attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors',
-  referrerPolicy: "no-referrer-when-downgrade",
+  referrerPolicy: "strict-origin-when-cross-origin",
 }).addTo(map);
 
 


### PR DESCRIPTION
The deprecated {s}.tile.osm.org CDN now returns OSM's "Access blocked" page. Switch to tile.openstreetmap.org and send a Referer per the OSM tile usage policy.