### PR TITLE
fix: index map study area navigation, add /ship command

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,53 @@
+---
+description: Push the current branch, open a PR to TaiBIF/devel, merge it, then merge TaiBIF devel into main
+argument-hint: [PR title]
+allowed-tools: Bash(git:*), Bash(gh:*), Read, AskUserQuestion
+---
+
+Ship the current work upstream: push → PR to `TaiBIF:devel` → merge → merge `TaiBIF:devel` into `TaiBIF:main`.
+
+Optional PR title from the user:
+
+$ARGUMENTS
+
+## Repo facts
+
+- `origin` = `moogoo78/camera-trap-server` (the user's fork). This is the only remote; there is no `upstream` remote — always target the parent repo with `gh --repo TaiBIF/camera-trap-server`.
+- Parent = `TaiBIF/camera-trap-server`, default branch `devel`. The user has ADMIN there.
+- `main` upstream is a long-lived release branch that sits behind `devel`.
+
+## Steps
+
+1. **Preflight.** Run `git status --short`, `git branch --show-current`, and `git log --oneline origin/<branch>..<branch>` (guard for a branch that has no upstream yet).
+   - The repo normally carries a pile of untracked scratch files (`tmp/`, `project-281/`, CSVs, …). Ignore them — never `git add -A`.
+   - If tracked files are modified or staged, stop and ask whether to commit them first. Do not commit on the user's behalf without a yes.
+   - If there is nothing unpushed and no branch divergence from `TaiBIF:devel`, say so and stop — there is nothing to ship.
+
+2. **Push.** `git push -u origin <branch>`. Never force-push.
+
+3. **PR into `TaiBIF:devel`.** First check for an existing open PR:
+   `gh pr list --repo TaiBIF/camera-trap-server --head moogoo78:<branch> --state open`
+   - Reuse it if one exists. Otherwise show the user the commits that would ship and the PR title/body you intend to use, and **ask for confirmation before creating it** — this posts to an organization repo.
+   - Create with:
+     `gh pr create --repo TaiBIF/camera-trap-server --base devel --head moogoo78:<branch> --title "..." --body "..."`
+   - Title: `$ARGUMENTS` if given, otherwise derive from the commits. Body: what changed and how it was verified. Note honestly if it was not verified against a running instance.
+
+4. **Merge that PR.** Ask for confirmation, then `gh pr merge <number> --repo TaiBIF/camera-trap-server --merge`.
+   - If the PR is not mergeable (conflicts, failing required checks), stop and report — do not attempt to resolve conflicts as part of this command.
+
+5. **Merge `TaiBIF:devel` into `TaiBIF:main`.** This is a release step touching the upstream release branch, so **always confirm separately** — a yes in step 4 does not carry over.
+   - Show what would move first: `gh api repos/TaiBIF/camera-trap-server/compare/main...devel --jq '{ahead:.ahead_by, behind:.behind_by, commits:[.commits[].commit.message|split("\n")[0]]}'`
+   - If `ahead_by` is 0, report that `main` is already current and stop.
+   - On confirmation, open and merge the release PR:
+     `gh pr create --repo TaiBIF/camera-trap-server --base main --head devel --title "release: devel → main" --body "..."`
+     then `gh pr merge <number> --repo TaiBIF/camera-trap-server --merge`.
+   - If a `devel → main` PR is already open, reuse it instead of creating a second one.
+
+6. **Report.** Give the user the PR URLs, both merge commit SHAs, and the resulting tip of `TaiBIF:main`. Mention that their local `devel` may now be behind and can be updated with `git pull`.
+
+## Rules
+
+- Stop at the first failure and report it. Do not retry a failed push or merge with different flags.
+- Never use `--force`, `--admin`, or `--squash` unless the user explicitly asks.
+- Every step that writes to `TaiBIF/*` (PR creation, both merges) needs its own explicit confirmation in chat. Do not batch them into one question.
+- Do not delete branches unless the user asks.

--- a/static/css/home.css
+++ b/static/css/home.css
@@ -23,6 +23,25 @@
   height: 100%;
 }
 
+/* 地圖返回鍵: 讓返回動作看得出來是可以點的按鈕 */
+.mapBackBtn {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 15px;
+  padding: 6px 16px;
+  border: 1px solid #257455;
+  border-radius: 16px;
+  background: none;
+  color: #257455;
+  font-size: 15px;
+  line-height: 1.4;
+}
+
+.mapBackBtn:hover {
+  background: #257455;
+  color: #FFF;
+}
+
 /*
 .banner {
   background-image: url('/static/image/banner.png');

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -286,6 +286,9 @@ $(function () {
   
 
 
+  // 正在進行中的樣區request, 用來取消還沒回來的舊request
+  let studyareaXhr = null;
+
   let map = L.map("map", {tap: false}).setView([23.5, 121.2], 7);
   L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
     maxZoom: 19,
@@ -345,11 +348,16 @@ $(function () {
               })
               .on("click", function (e) {
                 $('.loading-pop').removeClass('d-none')
-                $.ajax({
+                // 連續點不同樣區時, 取消上一個還沒回來的request, 避免舊資料蓋掉新的
+                if (studyareaXhr) {
+                  studyareaXhr.abort()
+                }
+                studyareaXhr = $.ajax({
                   url: '/api/stat_studyarea',
                   data: {"said": i[4], 'county': county},
                   dataType: "json",
                   success: function(response) {
+                    studyareaXhr = null
                     $('.loading-pop').addClass('d-none')
                     $('.city-box').addClass('d-none')
                     $('.pin-chartbox').removeClass('d-none')
@@ -357,7 +365,7 @@ $(function () {
                     //$('.map-explore').html(`<a class="link" onClick="resetMapExplore('${county}')">返回</a>`)
                     // 更換右側統計圖
                     $('.pin-chartbox').html(`
-
+                    <button class="mapBackBtn resetMapExplore" data-county="${county}">← 返回${county}</button>
                     <h2>${i[3]}</h2>
                     <div class="mbscro">
                       <div class="chart-box">
@@ -365,11 +373,10 @@ $(function () {
                       </div>
                     </div>
                     <div class="mapiconbox">
-                      <button class="resetMapExplore" data-county="${county}">< 返回</button>
                       <img src="/static/image/marker-icon.png" alt="">
                       <p>相機位置</p>
                     </div>
-                      `);                                        
+                      `);
                     $('.resetMapExplore').off('click')
                     $('.resetMapExplore').on('click', function(){
                       resetMapExplore($(this).data('county'))
@@ -436,9 +443,10 @@ $(function () {
                       legend:{ enabled:false },
                     });
                     // 更換左側地圖
-                    // 重設縮放 & 移除其他icon
+                    // 重設縮放, 保留樣區icon讓使用者可以直接點另一個樣區
                     map.setView([response.center[1], response.center[0]], 10);
-                    $('.myStudyAreaIcon').remove();
+                    $('.myDeploymentIcon').remove();
+                    $('.leaflet-tooltip').remove();
                     $('.countyPoly').addClass('d-none');
                     response.deployment_points.forEach(
                       (r) =>
@@ -452,7 +460,12 @@ $(function () {
                           .bindTooltip(r[3], { permanent: true, direction: 'top' })
                           .addTo(map)));
                   },
-                  error: function () {
+                  error: function (jqXHR, textStatus) {
+                    // abort是因為使用者又點了別的樣區, 交給新的request處理
+                    if (textStatus === 'abort') {
+                      return
+                    }
+                    studyareaXhr = null
                     $('.loading-pop').addClass('d-none')
                   }
                 })
@@ -461,7 +474,8 @@ $(function () {
         );
 
         $('.city-box').html(
-          `<h2>${county}</h2>
+          `<button class="mapBackBtn resetMapAll">← 返回全臺</button>
+          <h2>${county}</h2>
           <ul class="inflist">
           <li>
             <div class="left-title">計畫總數</div>
@@ -495,6 +509,8 @@ $(function () {
           </div>
           `
         )
+        $('.resetMapAll').off('click')
+        $('.resetMapAll').on('click', resetMapAll)
       }
   })
   }
@@ -514,14 +530,38 @@ $(function () {
   });
 
     function resetMapExplore(county){
+      if (studyareaXhr) {
+        studyareaXhr.abort();
+        studyareaXhr = null;
+      }
+      $('.loading-pop').addClass('d-none');
       $('.myDeploymentIcon').remove();
       $('.leaflet-tooltip').remove();
+      map.closePopup();
       map.setView([23.5, 121.2], 7);
       $('.countyPoly').removeClass('d-none');
       // trigger event
       $('.city-box').removeClass('d-none');
       $('.pin-chartbox').addClass('d-none')
       countyOnClick(county);
-    
+
+    }
+
+    // 回到最初的全臺地圖
+    function resetMapAll(){
+      if (studyareaXhr) {
+        studyareaXhr.abort();
+        studyareaXhr = null;
+      }
+      $('.loading-pop').addClass('d-none');
+      $('.myDeploymentIcon').remove();
+      $('.myStudyAreaIcon').remove();
+      $('.leaflet-tooltip').remove();
+      map.closePopup();
+      map.setView([23.5, 121.2], 7);
+      $('.countyPoly').removeClass('d-none');
+      $('.city-box').addClass('d-none');
+      $('.pin-chartbox').addClass('d-none');
+      $('.inf-box').removeClass('d-none').addClass('d-block');
     }
   


### PR DESCRIPTION
## fix: make index map navigable between study areas

Selecting a study area on the index map emptied the map: all 22 county polygons were hidden and every study area pin removed, leaving only a faint text link at the bottom of the right panel as the way back. The county level had no back control at all, and the intro panel was hidden permanently after the first county click.

- Study area pins now stay on the map, so another study area can be clicked directly. The previous study area's camera markers and tooltips are cleared on each switch.
- The back control moved to the top of the panel as a real button (`← 返回{county}`), styled via a new `.mapBackBtn` rule in `static/css/home.css`.
- Added `← 返回全臺` at the county level with a new `resetMapAll()`.
- A pending `/api/stat_studyarea` request is aborted when the user picks another study area or goes back, so a slow response can no longer overwrite the current view. Aborts are ignored in the error handler.

### Verification

Driven headlessly against the dev stack over CDP at 1440×900.

Anonymous: county → back button hit-tests correctly; select study area → `← 返回南投縣` on screen and hit-testable; switched directly 臺中分署 → 南投分署 with no back click; back → county restored (0 polygons hidden, 4 pins); back → intro panel and island view; then picked 嘉義縣 fresh.

Logged in as system admin: study area A → 6 camera markers; switch to B → 61 markers with A's 6 cleared (no accumulation); back → 0 markers, pins intact.

## chore: add /ship slash command

`.claude/commands/ship.md` — pushes the current branch, opens a PR to `TaiBIF:devel`, merges it, then merges `TaiBIF:devel` into `main`. Each write to the upstream repo requires its own confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)