### PR TITLE
feat: species-only edit mode; fix weekly modification notification

### DIFF
--- a/cron_scripts/check_modified_image.py
+++ b/cron_scripts/check_modified_image.py
@@ -11,6 +11,9 @@ from django.core.mail import send_mail
 #modified_images = ModifiedImage.objects.all().values()
 #df = pd.DataFrame(list(modified_images))
 
+# SES 單封信最多 50 個收件者, 超過整封會被退回
+SES_MAX_RECIPIENTS = 50
+
 modified_images = ModifiedImage.objects.all().values()
 df = pd.DataFrame(list(modified_images))
 # 確保 'last_updated' 欄位為 datetime 格式
@@ -31,7 +34,7 @@ print(today)
 
 if df2.empty:
     print('NO modified images for this week.')
-else: 
+else:
     # 影像可能已被刪除, 查不到就留空, 不要讓整個通知中斷
     def find_image_id(x):
         img = Image.objects.filter(pk=x).first()
@@ -39,57 +42,71 @@ else:
 
     groups = df2.groupby(['project_id', 'studyarea_id'])
     for (project_id, studyarea_id), group in groups:
-        studyarea_memebers = get_studyarea_member(project_id, studyarea_id)
-        email_list = [x.email for x in Contact.objects.filter(id__in=studyarea_memebers)]
-        # print(f'EMAIL LIST: {email_list}')
-        save_root = Path(settings.MEDIA_ROOT, 'email-attachment')
-        save_root.mkdir(parents=True, exist_ok=True)  # 檢查並創建目錄
-        save_path = os.path.join(save_root, f'{project_id}_{studyarea_id}.csv')
-        project_name = group['project'].iloc[0]
-        studyarea_name = group['studyarea'].iloc[0]
+        # 單一樣區出錯(信箱格式錯誤/AWS 憑證失效...)不能影響其他樣區的通知
+        try:
+            studyarea_memebers = get_studyarea_member(project_id, studyarea_id)
+            email_list = [x.email for x in Contact.objects.filter(id__in=studyarea_memebers)]
+            # 空白或格式錯誤的信箱會讓整批寄送失敗, 先濾掉
+            email_list = [x.strip() for x in email_list if x and '@' in x]
+            # print(f'EMAIL LIST: {email_list}')
+            if not email_list:
+                print(f'{project_id}_{studyarea_id}: NO valid recipient, skipped')
+                continue
+            save_root = Path(settings.MEDIA_ROOT, 'email-attachment')
+            save_root.mkdir(parents=True, exist_ok=True)  # 檢查並創建目錄
+            save_path = os.path.join(save_root, f'{project_id}_{studyarea_id}.csv')
+            project_name = group['project'].iloc[0]
+            studyarea_name = group['studyarea'].iloc[0]
 
-        # add Image.filename
-        group['filename'] = group['image_id'].map(find_image_id)
+            # add Image.filename
+            group['filename'] = group['image_id'].map(find_image_id)
 
-        group = group.drop(columns=['id', 'project_id', 'studyarea_id', 'image_id'])
-        group = group.rename(columns={
-            'last_updated': '最後更新日期',
-            'datetime':'影像拍攝日期時間',
-            'project':'計畫名稱',
-            'studyarea':'樣區名稱',
-            'deployment':'相機位置',
-            'filename': '原始檔案名稱',
-            'species':'物種',
-            'life_stage':'年齡',
-            'sex':'性別',
-            'antler':'角況',
-            'animal_id':'個體ID',
-            'remarks':'備註',
-            'modified_datetime':'修改後影像拍攝日期時間',
-            'modified_project':'修改後計畫名稱',
-            'modified_studyarea':'修改後樣區名稱',
-            'modified_deployment':'修改後相機位置',
-            'modified_species':'修改後物種',
-            'modified_life_stage':'修改後年齡',
-            'modified_sex':'修改後性別',
-            'modified_antler':'修改後角況',
-            'modified_animal_id':'修改後個體ID',
-            'modified_remarks':'修改後備註',
-        })
-        group.to_csv(save_path)
+            group = group.drop(columns=['id', 'project_id', 'studyarea_id', 'image_id'])
+            group = group.rename(columns={
+                'last_updated': '最後更新日期',
+                'datetime':'影像拍攝日期時間',
+                'project':'計畫名稱',
+                'studyarea':'樣區名稱',
+                'deployment':'相機位置',
+                'filename': '原始檔案名稱',
+                'species':'物種',
+                'life_stage':'年齡',
+                'sex':'性別',
+                'antler':'角況',
+                'animal_id':'個體ID',
+                'remarks':'備註',
+                'modified_datetime':'修改後影像拍攝日期時間',
+                'modified_project':'修改後計畫名稱',
+                'modified_studyarea':'修改後樣區名稱',
+                'modified_deployment':'修改後相機位置',
+                'modified_species':'修改後物種',
+                'modified_life_stage':'修改後年齡',
+                'modified_sex':'修改後性別',
+                'modified_antler':'修改後角況',
+                'modified_animal_id':'修改後個體ID',
+                'modified_remarks':'修改後備註',
+            })
+            group.to_csv(save_path)
 
-        download_url = f'https://camera-trap.tw/media/email-attachment/{project_id}_{studyarea_id}.csv'
-        email_body = f'''
-        您好：
+            download_url = f'https://camera-trap.tw/media/email-attachment/{project_id}_{studyarea_id}.csv'
+            email_body = f'''
+            您好：
 
-        您所負責的樣區（計畫名稱：{project_name}, 樣區名稱：{studyarea_name}）中的影像資料在過去一週內有經過修改。為了方便您查閱詳細的修改內容，請複製以下連結下載相關資料：
+            您所負責的樣區（計畫名稱：{project_name}, 樣區名稱：{studyarea_name}）中的影像資料在過去一週內有經過修改。為了方便您查閱詳細的修改內容，請複製以下連結下載相關資料：
 
-        下載修改內容：{download_url}
+            下載修改內容：{download_url}
 
-        如有任何問題，請隨時聯繫我們團隊。
+            如有任何問題，請隨時聯繫我們團隊。
 
-        臺灣自動相機資訊系統 團隊敬上
-        '''
-        send_mail(email_subject, email_body, settings.CT_SERVICE_EMAIL, email_list)
-
-        print(f'{project_id}_{studyarea_id}.csv was sent to {email_list}')
+            臺灣自動相機資訊系統 團隊敬上
+            '''
+            # 收件者超過上限要分批寄, 一批失敗不影響其他批
+            for i in range(0, len(email_list), SES_MAX_RECIPIENTS):
+                batch = email_list[i:i + SES_MAX_RECIPIENTS]
+                try:
+                    send_mail(email_subject, email_body, settings.CT_SERVICE_EMAIL, batch)
+                    print(f'{project_id}_{studyarea_id}.csv was sent to {batch}')
+                except Exception as e:
+                    print(f'{project_id}_{studyarea_id}: SEND FAILED for {batch}: {type(e).__name__}: {e}')
+        except Exception as e:
+            print(f'{project_id}_{studyarea_id}: SKIPPED: {type(e).__name__}: {e}')

--- a/cron_scripts/check_modified_image.py
+++ b/cron_scripts/check_modified_image.py
@@ -32,6 +32,11 @@ print(today)
 if df2.empty:
     print('NO modified images for this week.')
 else: 
+    # 影像可能已被刪除, 查不到就留空, 不要讓整個通知中斷
+    def find_image_id(x):
+        img = Image.objects.filter(pk=x).first()
+        return img.filename if img else ''
+
     groups = df2.groupby(['project_id', 'studyarea_id'])
     for (project_id, studyarea_id), group in groups:
         studyarea_memebers = get_studyarea_member(project_id, studyarea_id)
@@ -44,10 +49,6 @@ else:
         studyarea_name = group['studyarea'].iloc[0]
 
         # add Image.filename
-        def find_image_id(x):
-            img = Image.objects.get(pk=x)
-            return img.filename
-
         group['filename'] = group['image_id'].map(find_image_id)
 
         group = group.drop(columns=['id', 'project_id', 'studyarea_id', 'image_id'])
@@ -81,9 +82,9 @@ else:
         email_body = f'''
         您好：
 
-        您所負責的樣區（計畫名稱：{project_name}, 樣區名稱：{studyarea_name}）中的影像資料在過去一週內有經過修改。為了方便您查閱詳細的修改內容，請點擊以下連結下載相關資料：
+        您所負責的樣區（計畫名稱：{project_name}, 樣區名稱：{studyarea_name}）中的影像資料在過去一週內有經過修改。為了方便您查閱詳細的修改內容，請複製以下連結下載相關資料：
 
-        [下載修改內容]({download_url})
+        下載修改內容：{download_url}
 
         如有任何問題，請隨時聯繫我們團隊。
 

--- a/static/js/project_detail.js
+++ b/static/js/project_detail.js
@@ -248,7 +248,7 @@ function updateTable(page, page_from) {
         if ($('input[name="edit"]#edit-all').is(":checked")) {
           $("input[name='edit']").prop('checked', true)
         }      
-        $('.e-button, .d-button').removeClass('disabled')
+        $('.e-button').removeClass('disabled')
       }
 
       // 影像
@@ -1039,8 +1039,8 @@ $(document).ready(function () {
         <path id="Path_10217" data-name="Path 10217" d="M20,4.238a2.818,2.818,0,0,1-.855,2q-3.8,3.8-7.6,7.6-1.8,1.8-3.613,3.6a1.215,1.215,0,0,1-.45.279q-3.29,1.11-6.586,2.2a1.082,1.082,0,0,1-.4.078.546.546,0,0,1-.446-.786Q.775,17,1.512,14.792c.256-.769.509-1.54.774-2.306a1.037,1.037,0,0,1,.231-.384Q8.133,6.477,13.756.861A2.744,2.744,0,0,1,17.741.853q.734.724,1.46,1.457A2.747,2.747,0,0,1,20,4.238M7.447,16.318,17,6.767,13.233,3,3.678,12.549l3.768,3.769M17.837,5.967c.2-.192.414-.38.607-.587a1.622,1.622,0,0,0,.03-2.23c-.523-.565-1.071-1.108-1.634-1.633a1.578,1.578,0,0,0-2-.128,9.64,9.64,0,0,0-.828.753l3.824,3.825M6.4,16.925,3.073,13.6,1.406,18.587,6.4,16.925" transform="translate(0 0)" fill="#257455"/>
       </g>
     </svg>結束編輯`)
-      // show buttons
-      $('.d-button, .e-button').removeClass('d-none')
+      // show buttons: 刪除(.d-button)不開放, 保持隱藏
+      $('.e-button').removeClass('d-none')
       // bind onclick event
       $('.del-check').removeClass('d-none')
     } else {
@@ -1230,11 +1230,11 @@ $(document).ready(function () {
     } else {
       $('.edit-content input').prop("disabled", false)
       $('.edit-footer').removeClass('d-none')
-      // 僅開放物種及標註欄位（年齡/性別/角況/個體ID/備註）編輯，
-      // 鎖定日期、時間、計畫、樣區、相機位置。
+      // 只開放物種，其餘欄位全部鎖定（年齡/性別/角況/個體ID/備註/日期/時間/計畫/樣區/相機位置）。
       // 注意：樣區與相機位置不能只用 HTML readonly，因為 readonly 欄位仍可被
       // 點擊聚焦而觸發 autocomplete 下拉選單改值；必須一併 disabled 才會真正鎖定。
       $('#edit-date, #edit-time, #edit-project, #edit-studyarea, #edit-deployment').attr('disabled', 'disabled');
+      $('#edit-life_stage, #edit-sex, #edit-antler, #edit-animal_id, #edit-remarks').attr('disabled', 'disabled');
       $('.edit-date-cal').addClass('d-none');
       console.log('edit mode')
     }

--- a/taicat/templates/project/project_detail.html
+++ b/taicat/templates/project/project_detail.html
@@ -319,10 +319,8 @@
 				{% comment %} this could be part of datatable {% endcomment %}
 				<div class="right-btnaera">
 					{% if editable %}
-						{# 暫時停用編輯模式: disabled + 灰色樣式, 恢復時移除 disabled 與 style #}
-							<button class="edi-btn" id="edit_button" data-edit="off" disabled
-								title="編輯模式暫停開放"
-								style="opacity: 0.4; filter: grayscale(1); cursor: not-allowed; pointer-events: none;">
+						{# 編輯模式只開放修改物種 #}
+						<button class="edi-btn" id="edit_button" data-edit="off" title="編輯模式（僅開放修改物種）">
 							<svg id="Group_749" data-name="Group 749" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="19.999" viewBox="0 0 20 19.999">
 								<g id="Group_748" data-name="Group 748" clip-path="url(#clip-path)">
 									<path id="Path_10217" data-name="Path 10217" d="M20,4.238a2.818,2.818,0,0,1-.855,2q-3.8,3.8-7.6,7.6-1.8,1.8-3.613,3.6a1.215,1.215,0,0,1-.45.279q-3.29,1.11-6.586,2.2a1.082,1.082,0,0,1-.4.078.546.546,0,0,1-.446-.786Q.775,17,1.512,14.792c.256-.769.509-1.54.774-2.306a1.037,1.037,0,0,1,.231-.384Q8.133,6.477,13.756.861A2.744,2.744,0,0,1,17.741.853q.734.724,1.46,1.457A2.747,2.747,0,0,1,20,4.238M7.447,16.318,17,6.767,13.233,3,3.678,12.549l3.768,3.769M17.837,5.967c.2-.192.414-.38.607-.587a1.622,1.622,0,0,0,.03-2.23c-.523-.565-1.071-1.108-1.634-1.633a1.578,1.578,0,0,0-2-.128,9.64,9.64,0,0,0-.828.753l3.824,3.825M6.4,16.925,3.073,13.6,1.406,18.587,6.4,16.925" transform="translate(0 0)" fill="#257455"/>

--- a/taicat/views.py
+++ b/taicat/views.py
@@ -826,9 +826,26 @@ def delete_data(request, pk):
     return JsonResponse(response, safe=False)  # or JsonResponse({'data': data})
 
 
+def check_if_editable(request, project_id):
+    '''編輯權限: 系統管理員 / 個別計畫承辦人 / 該計畫的計畫總管理人'''
+    user_id = request.session.get('id', None)
+    if not user_id:
+        return False
+    # 系統管理員 / 個別計畫承辦人
+    if Contact.objects.filter(id=user_id, is_system_admin=True).first() or ProjectMember.objects.filter(member_id=user_id, role="project_admin", project_id=project_id):
+        return True
+    # 計畫總管理人
+    elif Contact.objects.filter(id=user_id, is_organization_admin=True):
+        organization_id = Contact.objects.filter(id=user_id, is_organization_admin=True).values('organization').first()['organization']
+        if Organization.objects.filter(id=organization_id, projects=project_id):
+            return True
+    return False
+
+
 def edit_image(request, pk):
-    # 暫時停用編輯模式: 禁止所有角色透過網頁編輯資料 (恢復時移除此段)
-    return JsonResponse({'species': [], 'folder_list': []}, safe=False)
+    # 編輯模式只開放修改物種, 其他欄位一律忽略
+    if not check_if_editable(request, pk):
+        return JsonResponse({'species': [], 'folder_list': []}, safe=False)
 
     if request.method == "POST":
         mode = Project.objects.filter(id=pk).first().mode
@@ -845,31 +862,13 @@ def edit_image(request, pk):
             .values('id','datetime','project__name','deployment__name','studyarea__name','species','life_stage','sex','antler','animal_id','remarks', 'project_id', 'studyarea_id')
         )
 
-        keys = ['species', 'life_stage', 'sex', 'antler', 'animal_id', 'remarks']
+        # 只接受 species, 年齡/性別/角況/個體ID/備註/日期時間/計畫/樣區/相機位置都不開放修改
         updated_dict = {}
-        for k in keys:
-            value = requests.get(k)
-            # Skip species if blank - keep existing value
-            if k == 'species' and not value:
-                continue
-            updated_dict.update({k: value})
+        if species_value := requests.get('species'):
+            updated_dict.update({'species': species_value})
 
-        project_id = requests.get('project_id')
-        if project_id:
-            updated_dict.update({'project_id': project_id})
-        if requests.get('studyarea_id'):
-            updated_dict.update({'studyarea_id': requests.get('studyarea_id')})
-        if requests.get('deployment_id'):
-            updated_dict.update({'deployment_id': requests.get('deployment_id')})
-        
-        date = requests.get('date')
-        time = requests.get('time')
-        if date and time:
-            datetime_str = f'{date} {time}'
-            datetime_object = datetime.datetime.strptime(datetime_str, '%Y-%m-%d %H:%M:%S')
-            datetime_object = datetime_object - datetime.timedelta(hours=8)
-            datetime_object = timezone.make_aware(datetime_object, timezone=timezone.utc)
-            updated_dict.update({'datetime': datetime_object})
+        # 影像不會換計畫, 後面的統計沿用原計畫
+        project_id = pk
 
         obj = Image.objects.filter(id__in=image_id)
         # obj_ori = obj


### PR DESCRIPTION
Three related changes: edit mode reopens for species only, and the weekly 影像資料修改通知 that reports those edits is repaired.

## feat: reopen edit mode for species only (`063447e`)

Edit mode was disabled for all roles. It is open again, restricted to 物種.

- `edit_image` now enforces permission **server-side** via a new `check_if_editable` (system admin / that project's `project_admin` / org admin of the project). It previously had no check at all and relied on the UI hiding the button, so a direct POST from anyone was accepted.
- Only `species` is applied. `life_stage`, `sex`, `antler`, `animal_id`, `remarks`, date/time, project, studyarea and deployment are ignored even when posted. `project_id` is pinned to `pk` so species-count bookkeeping still runs and the cross-project move path stays unused.
- The edit form disables every field except 物種, and the 刪除 button stays hidden in edit mode. `delete_data` remains disabled server-side, so deletion is blocked at both layers.

Verified on the dev stack by posting every field: anonymous and a plain uploader are rejected; system admin and `project_admin` change species only; the `ModifiedImage` audit row records the editor.

## fix: crash on deleted images (`80c7cfe`)

`find_image_id` used `Image.objects.get()`, so a single `ModifiedImage` row pointing at a deleted image raised `DoesNotExist` and aborted the whole weekly run. **3,571 of 170,242** existing rows reference images that no longer exist. Now looked up with `filter().first()`, leaving the filename blank when gone. The plaintext mail body also had a markdown link that recipients saw as literal `[下載修改內容](url)`; it is now a bare URL.

## fix: SES 50-recipient limit (`629af0a`)

Found in the production log at `/tmp/stat-every-week.log`:

```
botocore.exceptions.ClientError: An error occurred (InvalidParameterValue)
when calling the SendRawEmail operation: Recipient count exceeds 50.
```

One message per (project, studyarea) goes to the entire roster, and SES rejects more than 50 recipients. The exception was uncaught, so the run died at the first oversized group and every later group lost its mail too.

**The last four runs — 2026-07-06, 07-13, 07-20, 07-27 — sent zero emails.** 18 of 83 runs have failed this way. Rosters currently over the limit: study area 1944 (65), 1941 (55), 1942 (53).

- Send in batches of `SES_MAX_RECIPIENTS` (50).
- Wrap each batch and each group so one failure cannot cancel the rest, logging the group and exception.
- Drop blank/malformed addresses, the cause of 3 further failures with `Missing final '@domain'`, and log empty rosters instead of silently sending nothing.

Verified with 120 recipients and a forced mid-run failure: batches attempted `[50, 50, 20, 3]`, no batch over 50, the failing batch logged, and both the following batch and the next group still sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)